### PR TITLE
fix: getMyInfo NFT 없을 때 빈 배열 반환하도록 수정

### DIFF
--- a/server/utils/abi/testERC-721ABI.js
+++ b/server/utils/abi/testERC-721ABI.js
@@ -433,7 +433,7 @@ const erc721Abi = [
     }
 ]
 
-const contractAddress = "0x9Cb287cA0e6a1C82d71DEde24bBFF6dc8a794002";
+const contractAddress = "0xB20176f1e9f89026f0dEf4563eA3D2fbF3544356";
 
 const web3 = new Web3(new Web3.providers.HttpProvider("http://127.0.0.1:7545"));
 


### PR DESCRIPTION
userId 로 get 요청 시 보유한 NFT 가 없을 경우 빈 배열을 반환하도록 수정